### PR TITLE
package.json: fix engine definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "semver": "~5.0"
   },
   "engines": {
-    "nodejs": ">= 4.0.0"
+    "node": ">= 4.0.0"
   },
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
message when install current version: `warning node-hue-api@2.4.0: The engine "nodejs" appears to be invalid.`